### PR TITLE
Set the Route to link individual quiz to course page

### DIFF
--- a/flask/website/templates/coursePage.html
+++ b/flask/website/templates/coursePage.html
@@ -12,7 +12,7 @@
     <h3>Quizzes:</h3>
     <ul>
         {% for quiz in quizzes %}
-            <li>{{ quiz.quiz_name }}</li>
+            <li><a href="{{ url_for('views.quiz_page', course_id=course.id, quiz_id=quiz.id) }}">{{ quiz.quiz_name }}</a></li>
         {% endfor %}
     </ul>
 
@@ -24,7 +24,7 @@
     </ul>
 
     {% if current_user.user_type in ['teacher'] %}
-        <h3>Create New Quiz:</h3>
+        <h3>Create New Assignment:</h3>
         <a href="{{ url_for('views.createAssignment', course_id=course.id) }}">Create New Quiz</a>
     {% endif %}
 


### PR DESCRIPTION
- This pull request is for the complete route set up that links each quiz to a course from the dashboard.
- Entering URl on the browser is no longer required. Instead, navigation from the dashboard can be done easily.